### PR TITLE
Setting default onEditable function

### DIFF
--- a/addon/components/json-editor.js
+++ b/addon/components/json-editor.js
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
   onChange() {},
   onError() {},
   onModeChange() {},
-  onEditable() {},
+  onEditable(e) { return e;},
 
   init() {
     this._super(...arguments);


### PR DESCRIPTION
Jsoneditor wants the onEditable function to return either a boolean or an object with a field, value, and path, per https://github.com/josdejong/jsoneditor/blob/master/docs/api.md.

This just makes the default onEditable function return whatever was passed in.