### PR TITLE
Prevent resetting of the editor

### DIFF
--- a/addon/components/json-editor.js
+++ b/addon/components/json-editor.js
@@ -90,7 +90,7 @@ export default Component.extend({
 
   jsonChanged: observer('json', function() {
     // Only update json if it was change programatically
-    if (!this._isTyping && this.notDestroyed()) {
+    if (!this._isTyping && this.notDestroyed() && JSON.stringify(this.getJSON()) !== JSON.stringify(this.get('editor').get())) {
       this.get('editor').set(this.getJSON());
     }
   }),


### PR DESCRIPTION
Add a comparison to prevent the editor from resetting, and moving the caret to the top of the editor.